### PR TITLE
修复webpack配置中，sass-loader和resolve-url-loader中的顺序问题

### DIFF
--- a/lib/webpack-config/config/webpack.config.base.js
+++ b/lib/webpack-config/config/webpack.config.base.js
@@ -30,7 +30,7 @@ module.exports = config => ({
 				test: /\.(scss)$/,
 				loader: ExtractTextPlugin.extract({
 					fallback: "style-loader",
-					use: ["css-loader", "sass-loader", "resolve-url-loader"]
+					use: ["css-loader", "resolve-url-loader", "sass-loader"]
 				})
 			},
 			{


### PR DESCRIPTION
resolve-url-loader 应该配置在sass-loader之后。